### PR TITLE
FindYaml_cpp.cmake: search for yaml-cpp/yaml.h

### DIFF
--- a/cmake/modules/FindYaml_cpp.cmake
+++ b/cmake/modules/FindYaml_cpp.cmake
@@ -23,12 +23,12 @@
 FIND_PACKAGE(PkgConfig)
 PKG_CHECK_MODULES(PC_YAMLCPP QUIET yaml-cpp)
 
-FIND_PATH(YAMLCPP_INCLUDE_DIR yaml.h
+FIND_PATH(YAMLCPP_INCLUDE_DIR yaml-cpp/yaml.h
   HINTS
   ${PC_YAMLCPP_INCLUDEDIR}
   ${PC_YAMLCPP_INCLUDE_DIRS}
   $ENV{YAMLCPPDIR}
-  PATH_SUFFIXES include/yaml-cpp include yaml-cpp
+  PATH_SUFFIXES include/yaml-cpp include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
The code uses #include <yaml-cpp/yaml.h>, this implies that yaml-cpp/yaml.h should be on the header search path, not yaml.h.
This also fixes support for Haiku introduced in 706cbc1d255d12fc8148ee274c7c9e48728ca326